### PR TITLE
HAPI only supports TLS v1.2 - which is established here using curl co…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "require": {
     "php": ">=5.6",
+    "lib-curl": "*",
     "guzzlehttp/guzzle": "^6.2"
   },
   "require-dev": {

--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -110,6 +110,10 @@ class Tokenizer
                 'headers' => [
                     'User-Agent' => 'Gueststream/1.0',
                     'Accept' => 'application/json'
+                ],
+                'curl.options' => [
+                    // As of April 25th, 2016 HAPI only supports TLS v1.2
+                    CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1_2
                 ]
             ]
         );


### PR DESCRIPTION
…nfiguration items.